### PR TITLE
Office and center share same name bug

### DIFF
--- a/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
+++ b/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
@@ -150,7 +150,16 @@ public abstract class AbstractDataImportHandler implements DataImportHandler {
                     	else if(sheetName.equals("GlAccounts"))
                     		return ((Double)row.getCell(cell.getColumnIndex() - 1).getNumericCellValue()).intValue();
                     	else if(sheetName.equals("Clients") || sheetName.equals("Center")|| sheetName.equals("Groups") || sheetName.equals("Staff") ) 
-                    		return ((Double)row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).intValue();
+                    		/* Monkey patch - if office and center names are the same it errors out from looking
+                    		 for a number in a string. You have to check if the cell is a number, if not get the
+                    		  next column which will work when office and branch share names on group import.
+							*/
+							if (row.getCell(cell.getColumnIndex() + 1).getCellType() == Cell.CELL_TYPE_NUMERIC){
+								return ((Double)row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).intValue();
+							}
+							else {
+								return ((Double)row.getCell(cell.getColumnIndex() + 2).getNumericCellValue()).intValue();
+							}
                     }
             }
           }

--- a/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
+++ b/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
@@ -153,13 +153,13 @@ public abstract class AbstractDataImportHandler implements DataImportHandler {
                     		/* Monkey patch - if office and center names are the same it errors out from looking
                     		 for a number in a string. You have to check if the cell is a number, if not get the
                     		  next column which will work when office and branch share names on group import.
-							*/
-							if (row.getCell(cell.getColumnIndex() + 1).getCellType() == Cell.CELL_TYPE_NUMERIC){
-								return ((Double)row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).intValue();
-							}
-							else {
-								return ((Double)row.getCell(cell.getColumnIndex() + 2).getNumericCellValue()).intValue();
-							}
+				*/
+				if (row.getCell(cell.getColumnIndex() + 1).getCellType() == Cell.CELL_TYPE_NUMERIC){
+					return ((Double)row.getCell(cell.getColumnIndex() + 1).getNumericCellValue()).intValue();
+				}
+				else {
+					return ((Double)row.getCell(cell.getColumnIndex() + 2).getNumericCellValue()).intValue();
+				}
                     }
             }
           }


### PR DESCRIPTION
 if office and center names are the same it errors out from  for looking for a number in a string on group import. DataImport goes through row by row, col by col and looks for the first match. If the office is the same name it stops, and looks at the next col over for the id but finds the center name instead of a numerical id. You have to check if the cell is a number first, and if not get the next column.