### PR TITLE
Loan Import Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Setup Instructions
 
 1. Before you run the application, you need to have gradle installed and create a file dataimport.properties directly under your home directory. It should have the following 4 parameters:-
 
-  mifos.endpoint=https://demo.openmf.org/mifosng-provider/api/v1/  
+  mifos.endpoint=https://demo.openmf.org/fineract-provider/api/v1/  
   mifos.user.id=mifos  
   mifos.password=password  
   mifos.tenant.id=default  
@@ -24,6 +24,8 @@ Setup Instructions
 2. Use the command "gradle clean tomcatRunWar" to run the application and access it at localhost:8070/DataImportTool.
 
 3. If you are hosting the data import tool in the cloud, you need to ssh into the system to create the dataimport.properties file.
+
+Note :- Default gradlew config will allow you to remote debug on port 8006.
 
 Troubleshooting
 ===============

--- a/src/main/java/org/openmf/mifos/dataimport/dto/loan/Loan.java
+++ b/src/main/java/org/openmf/mifos/dataimport/dto/loan/Loan.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Locale;
 
 import org.openmf.mifos.dataimport.dto.Charge;
+import org.openmf.mifos.dataimport.utils.StringUtils;
 
 public class Loan {
 
@@ -78,7 +79,10 @@ public class Loan {
 		this.amortizationType = amortizationType;
 		this.clientId = clientId;
 		this.expectedDisbursementDate = expectedDisbursementDate;
-		this.fundId = fundId;
+		if(fundId == null || StringUtils.isBlank(fundId) || fundId.equalsIgnoreCase("0"))
+			this.fundId = null;
+		else
+			this.fundId = fundId;
 		this.externalId= externalId;
 		this.graceOnInterestCharged = graceOnInterestCharged;
 		this.graceOnInterestPayment = graceOnInterestPayment;

--- a/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
+++ b/src/main/java/org/openmf/mifos/dataimport/handler/AbstractDataImportHandler.java
@@ -6,6 +6,8 @@ import java.util.Iterator;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellValue;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -67,10 +69,25 @@ public abstract class AbstractDataImportHandler implements DataImportHandler {
         	Cell c = row.getCell(colIndex);
         	if (c == null || c.getCellType() == Cell.CELL_TYPE_BLANK)
         		return "";
-            return c.getStringCellValue().trim();
+        	FormulaEvaluator eval = row.getSheet().getWorkbook().getCreationHelper().createFormulaEvaluator();
+        	if(c.getCellType() == Cell.CELL_TYPE_FORMULA) {
+        		CellValue val = eval.evaluate(c);
+        		String res = trimEmptyDecimalPortion(val.getStringValue());
+        		return res.trim();
+        	}
+        	String res = trimEmptyDecimalPortion(c.getStringCellValue().trim());
+            return res.trim();
         } catch (Exception e) {
+        	e.printStackTrace();
             return ((Double)row.getCell(colIndex).getNumericCellValue()).intValue() + "";
         }
+    }
+    
+    private String trimEmptyDecimalPortion(String result) {
+    	if(result != null && result.endsWith(".0"))
+    		return	result.split("\\.")[0];
+    	else
+    		return result;
     }
 
     protected String readAsDate(int colIndex, Row row) {

--- a/src/main/java/org/openmf/mifos/dataimport/handler/loan/LoanDataImportHandler.java
+++ b/src/main/java/org/openmf/mifos/dataimport/handler/loan/LoanDataImportHandler.java
@@ -120,7 +120,7 @@ public class LoanDataImportHandler extends AbstractDataImportHandler {
         String fundName = readAsString(FUND_NAME_COL, row);
         String fundId;
         if (fundName.equals(""))
-            fundId = "";
+            fundId = null;
         else
             fundId = getIdByName(workbook.getSheet("Extras"), fundName).toString();
         String principal = readAsDouble(PRINCIPAL_COL, row).toString();
@@ -160,17 +160,20 @@ public class LoanDataImportHandler extends AbstractDataImportHandler {
         String arrearsTolerance = readAsString(ARREARS_TOLERANCE_COL, row);
         String repaymentStrategy = readAsString(REPAYMENT_STRATEGY_COL, row);
         String repaymentStrategyId = "";
-        if (repaymentStrategy.equalsIgnoreCase("Mifos style"))
+        if (repaymentStrategy.equalsIgnoreCase("Penalties, Fees, Interest, Principal order"))
             repaymentStrategyId = "1";
-        else if (repaymentStrategy.equalsIgnoreCase("Heavensfamily"))
+        else if (repaymentStrategy.equalsIgnoreCase("HeavensFamily Unique"))
             repaymentStrategyId = "2";
-        else if (repaymentStrategy.equalsIgnoreCase("Creocore"))
+        else if (repaymentStrategy.equalsIgnoreCase("Creocore Unique"))
             repaymentStrategyId = "3";
-        else if (repaymentStrategy.equalsIgnoreCase("RBI (India)"))
+        else if (repaymentStrategy.equalsIgnoreCase("Overdue/Due Fee/Int,Principal"))
             repaymentStrategyId = "4";
-        else if (repaymentStrategy.equalsIgnoreCase("Principal Interest Penalties Fees Order"))
+        else if (repaymentStrategy.equalsIgnoreCase("Principal, Interest, Penalties, Fees Order"))
             repaymentStrategyId = "5";
-        else if (repaymentStrategy.equalsIgnoreCase("Interest Principal Penalties Fees Order")) repaymentStrategyId = "6";
+        else if (repaymentStrategy.equalsIgnoreCase("Interest, Principal, Penalties, Fees Order"))
+        	repaymentStrategyId = "6";
+        else if(repaymentStrategy.equalsIgnoreCase("Early Repayment Strategy"))
+        	repaymentStrategyId = "7";
         String graceOnPrincipalPayment = readAsString(GRACE_ON_PRINCIPAL_PAYMENT_COL, row);
         String graceOnInterestPayment = readAsString(GRACE_ON_INTEREST_PAYMENT_COL, row);
         String graceOnInterestCharged = readAsString(GRACE_ON_INTEREST_CHARGED_COL, row);
@@ -325,7 +328,6 @@ public class LoanDataImportHandler extends AbstractDataImportHandler {
         Gson gson = new Gson();
         String payload = gson.toJson(loans.get(rowIndex));
         String response = restClient.post("loans", payload);
-
         return response;
     }
 

--- a/src/main/java/org/openmf/mifos/dataimport/populator/loan/LoanWorkbookPopulator.java
+++ b/src/main/java/org/openmf/mifos/dataimport/populator/loan/LoanWorkbookPopulator.java
@@ -293,7 +293,7 @@ public class LoanWorkbookPopulator extends AbstractWorkbookPopulator {
 	        	DataValidationConstraint amortizationConstraint = validationHelper.createExplicitListConstraint(new String[] {"Equal principal payments","Equal installments"});
 	        	DataValidationConstraint interestMethodConstraint = validationHelper.createExplicitListConstraint(new String[] {"Flat","Declining Balance"});
 	        	DataValidationConstraint interestCalculationPeriodConstraint = validationHelper.createExplicitListConstraint(new String[] {"Daily","Same as repayment period"});
-	        	DataValidationConstraint repaymentStrategyConstraint = validationHelper.createExplicitListConstraint(new String[] {"Mifos style","Heavensfamily","Creocore","RBI (India)","Principal Interest Penalties Fees Order","Interest Principal Penalties Fees Order"});
+	        	DataValidationConstraint repaymentStrategyConstraint = validationHelper.createExplicitListConstraint(new String[] {"Penalties, Fees, Interest, Principal order","HeavensFamily Unique","Creocore Unique","Overdue/Due Fee/Int,Principal","Principal, Interest, Penalties, Fees Order","Interest, Principal, Penalties, Fees Order", "Early Repayment Strategy"});
 	        	DataValidationConstraint arrearsToleranceConstraint = validationHelper.createIntegerConstraint(DataValidationConstraint.OperatorType.GREATER_OR_EQUAL, "0", null);
 	        	DataValidationConstraint graceOnPrincipalPaymentConstraint = validationHelper.createIntegerConstraint(DataValidationConstraint.OperatorType.GREATER_OR_EQUAL, "0", null);
 	        	DataValidationConstraint graceOnInterestPaymentConstraint = validationHelper.createIntegerConstraint(DataValidationConstraint.OperatorType.GREATER_OR_EQUAL, "0", null);


### PR DESCRIPTION
Items fixed :-   
Weird part is formula cells stopped providing raw content on calling getStringCellValue, hence using formula evaluator to get the actual content. This might be because LibreOffice is internally changing some stuff on saving back the template file as XLS.
New values added for Repayment Strategy.
API validation at platform side changed and stopped supporting an extra .0 for integer fields. Ex: It no longer accepts `noOfRepayments` as 24.0, hence code change strips the .0 in the end.